### PR TITLE
Fixed reference to os function. Autoformatted nvenv from v.

### DIFF
--- a/nvenv.v
+++ b/nvenv.v
@@ -210,7 +210,7 @@ fn uninstall(cmd Command) ? {
 	}
 
 	if !force && version == current_version {
-		utils.error_msg("Version $version cannot be uninstalled because it\'s in use, maybe you want to use `--force`?",
+		utils.error_msg('Version $version cannot be uninstalled because it\'s in use, maybe you want to use `--force`?',
 			1)
 	}
 

--- a/utils/utils.v
+++ b/utils/utils.v
@@ -68,7 +68,7 @@ pub fn check_current() string {
 		return ''
 	}
 
-	return base(full_path).trim('\n')
+	return os.base(full_path).trim('\n')
 }
 
 // Check if the given version is empty


### PR DESCRIPTION
Compiling using `make linux` gave the following error. Fixed.

```
utils/utils.v:71:9: error: unknown function: base
   69 |     }
   70 | 
   71 |     return base(full_path).trim('\n')
      |            ~~~~~~~~~~~~~~~
   72 | }
   73 |
```